### PR TITLE
allow hyphen character for variables/partials name

### DIFF
--- a/lib/Template/Mustache.pm
+++ b/lib/Template/Mustache.pm
@@ -205,7 +205,7 @@ delimiter_change_inner: '=' {
     $item[4]
 }
 
-partial: /\s*/ opening_tag '>' /\s*/ /[\w.]+/ /\s*/ closing_tag /\s*/ { 
+partial: /\s*/ opening_tag '>' /\s*/ /[-\w.]+/ /\s*/ closing_tag /\s*/ {
     my $prev = $thisparser->{prev_is_standalone};
     $thisparser->{prev_is_standalone} = 0;
     my $indent = '';
@@ -227,7 +227,7 @@ partial: /\s*/ opening_tag '>' /\s*/ /[\w.]+/ /\s*/ closing_tag /\s*/ {
         )
 }
 
-open_section: /\s*/ opening_tag /[#^]/ /\s*/ /[\w.]+/ /\s*/ closing_tag /\s*/ { 
+open_section: /\s*/ opening_tag /[#^]/ /\s*/ /[-\w.]+/ /\s*/ closing_tag /\s*/ {
     my $prev = $thisparser->{prev_is_standalone};
     $thisparser->{prev_is_standalone} = 0;
     if ( $item[1] =~ /\n/ or $prev ) {
@@ -341,7 +341,7 @@ variable: /\s*/ opening_tag /\s*/ variable_name /\s*/ closing_tag {
     );
 }
 
-variable_name: /[\w.]+/
+variable_name: /[-\w.]+/
 
 verbatim: { $thisparser->{opening_tag} } /^\s*\S*?(?=\Q$item[1]\E|\s|$)/ {
     $thisparser->{prev_is_standalone} = 0;

--- a/lib/Template/Mustache/Parser.pm
+++ b/lib/Template/Mustache/Parser.pm
@@ -2318,7 +2318,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::open_section
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [/\\s*/ opening_tag /[#^]/ /\\s*/ /[\\w.]+/ /\\s*/ closing_tag /\\s*/]},
+        Parse::RecDescent::_trace(q{Trying production: [/\\s*/ opening_tag /[#^]/ /\\s*/ /[-\\w.]+/ /\\s*/ closing_tag /\\s*/]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{open_section},
                       $tracelevel)
@@ -2442,15 +2442,15 @@ sub Parse::RecDescent::Template::Mustache::Parser::open_section
         push @item, $item{__PATTERN3__}=$current_match;
         
 
-        Parse::RecDescent::_trace(q{Trying terminal: [/[\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
+        Parse::RecDescent::_trace(q{Trying terminal: [/[-\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
                       q{open_section},
                       $tracelevel)
                         if defined $::RD_TRACE;
         undef $lastsep;
-        $expectation->is(q{/[\\w.]+/})->at($text);
+        $expectation->is(q{/[-\\w.]+/})->at($text);
         
 
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\w.]+)/)
+        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[-\w.]+)/)
         {
             $text = $lastsep . $text if defined $lastsep;
             $expectation->failed();
@@ -2590,7 +2590,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::open_section
         $item{__ACTION1__}=$_tok;
         
 
-        Parse::RecDescent::_trace(q{>>Matched production: [/\\s*/ opening_tag /[#^]/ /\\s*/ /[\\w.]+/ /\\s*/ closing_tag /\\s*/]<<},
+        Parse::RecDescent::_trace(q{>>Matched production: [/\\s*/ opening_tag /[#^]/ /\\s*/ /[-\\w.]+/ /\\s*/ closing_tag /\\s*/]<<},
                       Parse::RecDescent::_tracefirst($text),
                       q{open_section},
                       $tracelevel)
@@ -2830,7 +2830,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::partial
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [/\\s*/ opening_tag '>' /\\s*/ /[\\w.]+/ /\\s*/ closing_tag /\\s*/]},
+        Parse::RecDescent::_trace(q{Trying production: [/\\s*/ opening_tag '>' /\\s*/ /[-\\w.]+/ /\\s*/ closing_tag /\\s*/]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{partial},
                       $tracelevel)
@@ -2955,15 +2955,15 @@ sub Parse::RecDescent::Template::Mustache::Parser::partial
         push @item, $item{__PATTERN2__}=$current_match;
         
 
-        Parse::RecDescent::_trace(q{Trying terminal: [/[\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
+        Parse::RecDescent::_trace(q{Trying terminal: [/[-\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
                       q{partial},
                       $tracelevel)
                         if defined $::RD_TRACE;
         undef $lastsep;
-        $expectation->is(q{/[\\w.]+/})->at($text);
+        $expectation->is(q{/[-\\w.]+/})->at($text);
         
 
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\w.]+)/)
+        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[-\w.]+)/)
         {
             $text = $lastsep . $text if defined $lastsep;
             $expectation->failed();
@@ -3108,7 +3108,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::partial
         $item{__ACTION1__}=$_tok;
         
 
-        Parse::RecDescent::_trace(q{>>Matched production: [/\\s*/ opening_tag '>' /\\s*/ /[\\w.]+/ /\\s*/ closing_tag /\\s*/]<<},
+        Parse::RecDescent::_trace(q{>>Matched production: [/\\s*/ opening_tag '>' /\\s*/ /[-\\w.]+/ /\\s*/ closing_tag /\\s*/]<<},
                       Parse::RecDescent::_tracefirst($text),
                       q{partial},
                       $tracelevel)
@@ -5272,7 +5272,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::variable_name
     my $text;
     my $lastsep;
     my $current_match;
-    my $expectation = new Parse::RecDescent::Expectation(q{/[\\w.]+/});
+    my $expectation = new Parse::RecDescent::Expectation(q{/[-\\w.]+/});
     $expectation->at($_[1]);
     
     my $thisoffset;
@@ -5286,7 +5286,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::variable_name
     while (!$_matched && !$commit)
     {
         
-        Parse::RecDescent::_trace(q{Trying production: [/[\\w.]+/]},
+        Parse::RecDescent::_trace(q{Trying production: [/[-\\w.]+/]},
                       Parse::RecDescent::_tracefirst($_[1]),
                       q{variable_name},
                       $tracelevel)
@@ -5299,7 +5299,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::variable_name
         my $repcount = 0;
 
 
-        Parse::RecDescent::_trace(q{Trying terminal: [/[\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
+        Parse::RecDescent::_trace(q{Trying terminal: [/[-\\w.]+/]}, Parse::RecDescent::_tracefirst($text),
                       q{variable_name},
                       $tracelevel)
                         if defined $::RD_TRACE;
@@ -5307,7 +5307,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::variable_name
         $expectation->is(q{})->at($text);
         
 
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\w.]+)/)
+        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[-\w.]+)/)
         {
             $text = $lastsep . $text if defined $lastsep;
             $expectation->failed();
@@ -5326,7 +5326,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::variable_name
         push @item, $item{__PATTERN1__}=$current_match;
         
 
-        Parse::RecDescent::_trace(q{>>Matched production: [/[\\w.]+/]<<},
+        Parse::RecDescent::_trace(q{>>Matched production: [/[-\\w.]+/]<<},
                       Parse::RecDescent::_tracefirst($text),
                       q{variable_name},
                       $tracelevel)
@@ -6260,13 +6260,13 @@ package Template::Mustache::Parser; sub new { my $self = bless( {
                                                                                                      'rdelim' => '/'
                                                                                                    }, 'Parse::RecDescent::Token' ),
                                                                                             bless( {
-                                                                                                     'description' => '/[\\\\w.]+/',
+                                                                                                     'description' => '/[-\\\\w.]+/',
                                                                                                      'hashname' => '__PATTERN4__',
                                                                                                      'ldelim' => '/',
                                                                                                      'line' => 62,
                                                                                                      'lookahead' => 0,
                                                                                                      'mod' => '',
-                                                                                                     'pattern' => '[\\w.]+',
+                                                                                                     'pattern' => '[-\\w.]+',
                                                                                                      'rdelim' => '/'
                                                                                                    }, 'Parse::RecDescent::Token' ),
                                                                                             bless( {
@@ -6410,13 +6410,13 @@ package Template::Mustache::Parser; sub new { my $self = bless( {
                                                                                                 'rdelim' => '/'
                                                                                               }, 'Parse::RecDescent::Token' ),
                                                                                        bless( {
-                                                                                                'description' => '/[\\\\w.]+/',
+                                                                                                'description' => '/[-\\\\w.]+/',
                                                                                                 'hashname' => '__PATTERN3__',
                                                                                                 'ldelim' => '/',
                                                                                                 'line' => 40,
                                                                                                 'lookahead' => 0,
                                                                                                 'mod' => '',
-                                                                                                'pattern' => '[\\w.]+',
+                                                                                                'pattern' => '[-\\w.]+',
                                                                                                 'rdelim' => '/'
                                                                                               }, 'Parse::RecDescent::Token' ),
                                                                                        bless( {
@@ -7123,13 +7123,13 @@ package Template::Mustache::Parser; sub new { my $self = bless( {
                                                                                 'error' => undef,
                                                                                 'items' => [
                                                                                              bless( {
-                                                                                                      'description' => '/[\\\\w.]+/',
+                                                                                                      'description' => '/[-\\\\w.]+/',
                                                                                                       'hashname' => '__PATTERN1__',
                                                                                                       'ldelim' => '/',
                                                                                                       'line' => 176,
                                                                                                       'lookahead' => 0,
                                                                                                       'mod' => '',
-                                                                                                      'pattern' => '[\\w.]+',
+                                                                                                      'pattern' => '[-\\w.]+',
                                                                                                       'rdelim' => '/'
                                                                                                     }, 'Parse::RecDescent::Token' )
                                                                                            ],

--- a/t/basic.t
+++ b/t/basic.t
@@ -13,6 +13,7 @@ sub render_ok(@) {
 render_ok @$_ for (
     [ "Hello {{planet}}", {planet => "World!"}, 'Hello World!' ],
     [ "{{a}} and {{b}}", {a => 'this', b => 'that' }, 'this and that' ],
+    [ "{{c-d}} and {{e.f}}", {'c-d' => 'this', 'e' => { f => 'that' } }, 'this and that' ],
     [ '123{{! no }}456', {}, '123456', 'comment' ],
     [ q(Begin
 {{!

--- a/t/partials.t
+++ b/t/partials.t
@@ -14,4 +14,14 @@ my $mustache = Template::Mustache->new(
 
 is $mustache->render, 'xYay!', 'partial';
 
+
+$mustache = Template::Mustache->new(
+    partials => {
+        'inner-hyphen' => 'Yay!Yay!'
+    },
+    template => 'x{{> inner-hyphen}}'
+);
+
+is $mustache->render, 'xYay!Yay!', 'hyphen';
+
 done_testing;

--- a/t/sections.t
+++ b/t/sections.t
@@ -12,6 +12,9 @@ is( Template::Mustache->render( "{{#foo}}{{.}}{{/foo}}", {foo => "World!"})
 is( Template::Mustache->render( "{{#foo }}{{.}}{{/foo}}", {foo => "World!"})
     => 'World!', 'spaces' );
 
+is( Template::Mustache->render( "{{#foo-bar}}{{.}}{{/foo-bar}}", {'foo-bar' => "World!"})
+    => 'World!', 'hyphen' );
+
 
 is ''.Template::Mustache->render( "{{#foo }}{{.}}{{/foo }}", {foo => "World!"})
     => 'World!', 'spaces';


### PR DESCRIPTION
Hello.
In our products, using variables/partials named by kebab-case.
So when we updated Template::Mustache from 0.5.6, our code has broken in 1.0.0 or later.
I'm happy if you consider to allow using hyphen character as variables/partials name.