### PR TITLE
fix False [] range "/-\w" in regex

### DIFF
--- a/lib/Template/Mustache/Parser.pm
+++ b/lib/Template/Mustache/Parser.pm
@@ -2964,7 +2964,7 @@ sub Parse::RecDescent::Template::Mustache::Parser::partial
         $expectation->is(q{/[\\/-\\w.]+/})->at($text);
         
 
-        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\/-\w.]+)/)
+        unless ($text =~ s/\A($skip)/$lastsep=$1 and ""/e and   $text =~ m/\A(?:[\/\w.-]+)/)
         {
             $text = $lastsep . $text if defined $lastsep;
             $expectation->failed();


### PR DESCRIPTION
This commit resolves Perl >= 5.2 warning:

False [] range "/-\w" in regex; marked by <-- HERE in m/\A(?:[/-\w <-- HERE .]+)/

Note that the character - in the previous bracketed class can be understood as a range of characters.